### PR TITLE
Implement reciprocal rank fusion for retrieval

### DIFF
--- a/src/debate_loop.py
+++ b/src/debate_loop.py
@@ -125,9 +125,9 @@ def _hybrid_search(query: str, docs, bm25, encoder, f_index, k=6):
 
     scores = {}
     for rank, idx in enumerate(bm_order, start=1):
-        scores[idx] = scores.get(idx, 0.0) + 1.0 / (k + rank)
+        scores[idx] = scores.get(idx, 0.0) + 1.0 / (60 + rank)
     for rank, idx in enumerate(dense_order, start=1):
-        scores[idx] = scores.get(idx, 0.0) + 1.0 / (k + rank)
+        scores[idx] = scores.get(idx, 0.0) + 1.0 / (60 + rank)
 
     top = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:k]
     return [

--- a/src/debate_loop.py
+++ b/src/debate_loop.py
@@ -121,8 +121,7 @@ def _hybrid_search(query: str, docs, bm25, encoder, f_index, k=6):
     q_emb = encoder.encode([query], show_progress_bar=False)
     faiss.normalize_L2(q_emb)
     dense_scores, dense_ids = f_index.search(q_emb, k)
-    dense_order = np.argsort(dense_scores[0])[::-1][:k]
-    dense_order = dense_ids[0][dense_order]
+    dense_order = dense_ids[0]
 
     scores = {}
     for rank, idx in enumerate(bm_order, start=1):


### PR DESCRIPTION
## Summary
- merge BM25 and FAISS retrieval results with Reciprocal Rank Fusion
- update hybrid search docstring to mention RRF

## Testing
- `python -m py_compile src/debate_loop.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f92d6d60c8323a918c29d2408ca88