### PR TITLE
Implement dataset packaging for SFT and DPO

### DIFF
--- a/src/pack_dpo.py
+++ b/src/pack_dpo.py
@@ -1,14 +1,106 @@
+"""src.pack_dpo
+================
+
+Create DPO (Direct Preference Optimisation) training pairs for a given batch.
+The script reads accepted and rejected turns from ``runs/<batch_id>`` and
+emits a JSONL shard matching :mod:`schemas/dpo.schema.json`.
+
+For each ``(speaker, topic)`` combination exactly one entry is produced.  A
+rejected turn with the same ``speaker`` and ``topic`` is preferred; if none is
+available an ablated version of the accepted response is used instead so that
+the resulting JSONL still conforms to the schema.
 """
-File: src/pack_dpo.py
-Purpose: Package accepted vs rejected into DPO JSONL.
-Inputs: --batch <batch_id>
-Outputs: datasets/dpo/<batch_id>.jsonl
-"""
+
+from __future__ import annotations
+
 import argparse
-def main():
+import json
+import uuid
+from pathlib import Path
+from typing import Dict, Any, Tuple
+
+
+def _load_turn(path: Path) -> Dict[str, Any]:
+    """Normalise an accepted or rejected turn into a flat dict."""
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    meta = data.get("meta", {})
+    return {
+        "prompt": data.get("instruction")
+        or data.get("prompt")
+        or meta.get("topic")
+        or data.get("topic", ""),
+        "response": data.get("response") or data.get("text", ""),
+        "speaker": meta.get("speaker") or data.get("speaker", ""),
+        "topic": meta.get("topic")
+        or data.get("topic")
+        or data.get("instruction")
+        or data.get("prompt", ""),
+    }
+
+
+def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--batch", required=True)
+    ap.add_argument("--batch", required=True, help="Batch identifier")
     args = ap.parse_args()
-    print("[pack_dpo] Placeholder. Use auto_runner --dry-run to generate example DPO JSONL.")
-if __name__ == "__main__":
+
+    batch_id = args.batch
+    base_dir = Path("runs") / batch_id
+    acc_dir = base_dir / "accepted"
+    rej_dir = base_dir / "rejected"
+    out_dir = Path("datasets") / "dpo"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not acc_dir.exists():
+        raise SystemExit(f"[pack_dpo] Missing directory: {acc_dir}")
+
+    accepted: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for fp in sorted(acc_dir.glob("*.json")):
+        t = _load_turn(fp)
+        accepted[(t["speaker"], t["topic"])] = t
+
+    rejected: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    if rej_dir.exists():
+        for fp in sorted(rej_dir.glob("*.json")):
+            t = _load_turn(fp)
+            rejected[(t["speaker"], t["topic"])] = t
+
+    items = []
+    for key, acc in accepted.items():
+        rej = rejected.get(key)
+        if rej:
+            rejected_text = rej["response"]
+            audit_diffs = "rejected"
+        else:
+            # Ablated negative: prefix to indicate non-preferred variant
+            rejected_text = f"(ablated) {acc['response']}"
+            audit_diffs = "ablated accepted; no rejected turn"
+
+        items.append(
+            {
+                "id": f"{batch_id}.{uuid.uuid4().hex[:8]}",
+                "prompt": acc["prompt"],
+                "chosen": acc["response"],
+                "rejected": rejected_text,
+                "meta": {
+                    "speaker": acc["speaker"],
+                    "topic": acc["topic"],
+                    "batch_id": batch_id,
+                    "audit_diffs": audit_diffs,
+                },
+            }
+        )
+
+    out_path = out_dir / f"{batch_id}.jsonl"
+    with open(out_path, "w", encoding="utf-8") as f:
+        for it in items:
+            f.write(json.dumps(it, ensure_ascii=False) + "\n")
+
+    print(f"[pack_dpo] Wrote {out_path} ({len(items)} items)")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
+

--- a/src/pack_sft.py
+++ b/src/pack_sft.py
@@ -1,14 +1,123 @@
+"""src.pack_sft
+================
+
+Collect accepted turns for a given ``batch_id`` and write them to a single
+JSONL shard compatible with :mod:`schemas/sft.schema.json`.
+
+The module expects the following directory layout::
+
+    runs/<batch_id>/accepted/*.json
+
+Each file should contain the generated response together with metadata such as
+``speaker`` and ``topic``.  The exact structure is flexible – only the fields
+required by the final schema are extracted.  A minimal example of an accepted
+turn is::
+
+    {
+        "instruction": "De libero arbitrio",
+        "response": "... Latin response ...",
+        "meta": {
+            "speaker": "Aquinas",
+            "topic": "De libero arbitrio",
+            "citations": [{"work": "ST I-II", "ref": "q109 a2"}],
+            "provenance": [{"work": "ST I-II", "ref": "q109 a2", "snippet": "..."}],
+            "audit_summary": {"claims": 5, "correct": 4, "support_rate": 0.8},
+            "encoder": "intfloat/multilingual-e5-base",
+            "model": "Meta-Llama-3-8B-Instruct",
+            "commit": "abcdef"
+        }
+    }
+
+Only files under ``runs/<batch_id>/accepted`` are inspected.  The resulting
+shard is written to ``datasets/sft/<batch_id>.jsonl`` and can be validated via
+``python -m src.validate_jsonl``.
 """
-File: src/pack_sft.py
-Purpose: Package accepted turns into SFT JSONL.
-Inputs: --batch <batch_id>
-Outputs: datasets/sft/<batch_id>.jsonl
-"""
+
+from __future__ import annotations
+
 import argparse
-def main():
+import json
+import uuid
+from pathlib import Path
+from typing import Dict, Any
+
+
+def _load_turn(path: Path) -> Dict[str, Any]:
+    """Return a normalised representation of a turn.
+
+    The accepted turn files produced by earlier pipeline stages may vary in
+    structure.  This helper pulls out the fields required by the SFT schema,
+    providing sensible defaults when optional information is missing.
+    """
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    meta = data.get("meta", {})
+    turn = {
+        "instruction": data.get("instruction")
+        or data.get("prompt")
+        or meta.get("topic")
+        or data.get("topic", ""),
+        "response": data.get("response") or data.get("text", ""),
+        "speaker": meta.get("speaker") or data.get("speaker", ""),
+        "topic": meta.get("topic")
+        or data.get("topic")
+        or data.get("instruction")
+        or data.get("prompt", ""),
+        "citations": meta.get("citations") or data.get("citations", []),
+        "provenance": meta.get("provenance") or data.get("provenance", []),
+        "audit_summary": meta.get("audit_summary")
+        or data.get("audit_summary", {}),
+        "encoder": meta.get("encoder", ""),
+        "model": meta.get("model", ""),
+        "commit": meta.get("commit", ""),
+    }
+    return turn
+
+
+def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--batch", required=True)
+    ap.add_argument("--batch", required=True, help="Batch identifier")
     args = ap.parse_args()
-    print("[pack_sft] Placeholder. Use auto_runner --dry-run to generate example SFT JSONL.")
-if __name__ == "__main__":
+
+    batch_id = args.batch
+    runs_dir = Path("runs") / batch_id / "accepted"
+    out_dir = Path("datasets") / "sft"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not runs_dir.exists():
+        raise SystemExit(f"[pack_sft] Missing directory: {runs_dir}")
+
+    items = []
+    for fp in sorted(runs_dir.glob("*.json")):
+        turn = _load_turn(fp)
+        item = {
+            "id": f"{batch_id}.{uuid.uuid4().hex[:8]}",
+            "instruction": turn["instruction"],
+            "response": turn["response"],
+            "meta": {
+                "speaker": turn["speaker"],
+                "topic": turn["topic"],
+                "citations": turn["citations"],
+                "provenance": turn["provenance"],
+                "audit_summary": turn["audit_summary"],
+                "batch_id": batch_id,
+                "encoder": turn["encoder"],
+                "model": turn["model"],
+                "commit": turn["commit"],
+            },
+        }
+        items.append(item)
+
+    out_path = out_dir / f"{batch_id}.jsonl"
+    with open(out_path, "w", encoding="utf-8") as f:
+        for it in items:
+            f.write(json.dumps(it, ensure_ascii=False) + "\n")
+
+    print(f"[pack_sft] Wrote {out_path} ({len(items)} items)")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
+


### PR DESCRIPTION
## Summary
- implement `src.pack_sft` to collect accepted turns into SFT shard
- implement `src.pack_dpo` to pair accepted vs rejected turns into DPO shard

## Testing
- `python -m src.pack_sft --batch batch1`
- `python -m src.pack_dpo --batch batch1`
- `python -m src.validate_jsonl --input datasets/sft/batch1.jsonl --schema schemas/sft.schema.json`
- `python -m src.validate_jsonl --input datasets/dpo/batch1.jsonl --schema schemas/dpo.schema.json`


------
https://chatgpt.com/codex/tasks/task_e_689fa7a08d6c8323b4abc6182a2e15d7