### PR TITLE
Build dense and sparse retrieval indices

### DIFF
--- a/src/chunk_and_index.py
+++ b/src/chunk_and_index.py
@@ -86,9 +86,9 @@ def main() -> None:
     for path in sorted(corpora_dir.rglob("*.txt")):
         with open(path, "r", encoding="utf-8") as f:
             text = f.read()
-        for ch in chunk_text(text):
-            chunks.append(ch)
-            tokenized.append(ch.split())
+        for token_list in chunk_text(text):
+            chunks.append(" ".join(token_list))
+            tokenized.append(token_list)
 
     if not chunks:
         raise ValueError(f"no .txt corpora found under {corpora_dir}")


### PR DESCRIPTION
## Summary
- chunk Latin corpora into fixed-size segments
- encode chunks with intfloat/multilingual-e5-base and populate FAISS
- build BM25 index and persist metadata with file checksums

## Testing
- `python -m py_compile src/chunk_and_index.py`
- `python -m src.chunk_and_index --config configs/default.ci.yaml --dry-run`
- `python -m src.chunk_and_index --config configs/default.ci.yaml` *(fails: ProxyError unable to download model)*

------
https://chatgpt.com/codex/tasks/task_e_689fa79da9948323b6070efdbe65ea55