### PR TITLE
refactor: centralize model and encoder names

### DIFF
--- a/src/auto_runner.py
+++ b/src/auto_runner.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from .config import load_config
 from .utils.logging import write_json, now_iso
 
+ENCODER_NAME = "intfloat/multilingual-e5-base"
+
 def _load_topics(path: str):
     import yaml
     with open(path, "r", encoding="utf-8") as f:
@@ -23,6 +25,7 @@ def main():
     args = ap.parse_args()
 
     cfg = load_config(args.config)
+    model_name = cfg["personas"]["model"].split('/')[-1]
     topics = _load_topics(args.topics)
     batch_id = cfg["batch_id"]
 
@@ -62,8 +65,8 @@ def main():
                     "provenance": [{"work":"Summa Theologiae I-II","ref":"q109 a2","snippet":"gratia non tollit naturam"}],
                     "audit_summary": audit,
                     "batch_id": batch_id,
-                    "encoder": "intfloat/multilingual-e5-base",
-                    "model": "Meta-Llama-3-8B-Instruct",
+                    "encoder": ENCODER_NAME,
+                    "model": model_name,
                     "commit": ""
                 }
             }
@@ -92,7 +95,7 @@ def main():
         "kpis":{"support_rate_avg":0.8,"latinness_avg":0.25,"citations_avg":1.5,"novelty_max":0.8},
         "counts":{"topics":len(topics["topics"]),"turns_total":len(topics["topics"])*len(speakers),"accepted":len(topics["topics"])*len(speakers),"rejected":0},
         "artifacts":{"sft":str(sft_path),"dpo":str(dpo_path)},
-        "versions":{"encoder":"intfloat/multilingual-e5-base","model":"Meta-Llama-3-8B-Instruct"},
+        "versions":{"encoder":ENCODER_NAME,"model":model_name},
         "created_at": now_iso()
     }
     write_json(runs_dir/"summary.json", summary)


### PR DESCRIPTION
## Summary
- centralize multilingual-e5 encoder name in auto_runner
- derive Llama model name from config instead of hardcoding

## Testing
- `pip install pyyaml`
- `python -m py_compile src/auto_runner.py`
- `make smoke`


------
https://chatgpt.com/codex/tasks/task_e_689fbae796d483239bdbca42a969f1ee