### PR TITLE
refactor: centralize model and encoder names

### DIFF
--- a/src/auto_runner.py
+++ b/src/auto_runner.py
@@ -24,7 +24,7 @@ def main():
     args = ap.parse_args()
 
     cfg = load_config(args.config)
-    model_name = cfg["personas"]["model"].split('/')[-1]
+    model_name = Path(cfg["personas"]["model"]).name
     topics = _load_topics(args.topics)
     batch_id = cfg["batch_id"]
 

--- a/src/auto_runner.py
+++ b/src/auto_runner.py
@@ -8,6 +8,7 @@ import argparse, json, uuid, os, random
 from pathlib import Path
 from .config import load_config
 from .utils.logging import write_json, now_iso
+from .constants import ENCODER_NAME
 
 def _load_topics(path: str):
     import yaml
@@ -23,6 +24,7 @@ def main():
     args = ap.parse_args()
 
     cfg = load_config(args.config)
+    model_name = cfg["personas"]["model"].split('/')[-1]
     topics = _load_topics(args.topics)
     batch_id = cfg["batch_id"]
 
@@ -62,8 +64,8 @@ def main():
                     "provenance": [{"work":"Summa Theologiae I-II","ref":"q109 a2","snippet":"gratia non tollit naturam"}],
                     "audit_summary": audit,
                     "batch_id": batch_id,
-                    "encoder": "intfloat/multilingual-e5-base",
-                    "model": "Meta-Llama-3-8B-Instruct",
+                    "encoder": ENCODER_NAME,
+                    "model": model_name,
                     "commit": ""
                 }
             }
@@ -92,7 +94,7 @@ def main():
         "kpis":{"support_rate_avg":0.8,"latinness_avg":0.25,"citations_avg":1.5,"novelty_max":0.8},
         "counts":{"topics":len(topics["topics"]),"turns_total":len(topics["topics"])*len(speakers),"accepted":len(topics["topics"])*len(speakers),"rejected":0},
         "artifacts":{"sft":str(sft_path),"dpo":str(dpo_path)},
-        "versions":{"encoder":"intfloat/multilingual-e5-base","model":"Meta-Llama-3-8B-Instruct"},
+        "versions":{"encoder":ENCODER_NAME,"model":model_name},
         "created_at": now_iso()
     }
     write_json(runs_dir/"summary.json", summary)

--- a/src/chunk_and_index.py
+++ b/src/chunk_and_index.py
@@ -9,6 +9,7 @@ import argparse, json
 from pathlib import Path
 from .config import load_config
 from .utils.logging import write_json, now_iso
+from .constants import ENCODER_NAME
 
 def main():
     ap = argparse.ArgumentParser()
@@ -20,11 +21,11 @@ def main():
     indices = Path(cfg["paths"]["indices"])
     indices.mkdir(parents=True, exist_ok=True)
     meta = {
-        "encoder":"intfloat/multilingual-e5-base",
+        "encoder": ENCODER_NAME,
         "built_at": now_iso(),
         "faiss": "todo:version",
         "bm25": "rank_bm25",
-        "notes":"stub meta in dry-run"
+        "notes": "stub meta in dry-run",
     }
     write_json(indices/"meta.json", meta)
     print(f"[chunk_and_index] wrote {indices/'meta.json'}")

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,5 @@
+"""
+Shared constants for the philosopher-theologian dataset factory.
+"""
+
+ENCODER_NAME = "intfloat/multilingual-e5-base"


### PR DESCRIPTION
## Summary
- derive Llama model name from config instead of hardcoding
- centralize multilingual-e5 encoder in shared constants module used by auto_runner and chunk_and_index

## Testing
- `pip install pyyaml`
- `python -m py_compile src/auto_runner.py src/chunk_and_index.py src/constants.py`
- `make smoke`


------
https://chatgpt.com/codex/tasks/task_e_689fbae796d483239bdbca42a969f1ee