### PR TITLE
make pack scripts configurable

### DIFF
--- a/src/pack_dpo.py
+++ b/src/pack_dpo.py
@@ -2,8 +2,10 @@
 ================
 
 Create DPO (Direct Preference Optimisation) training pairs for a given batch.
-The script reads accepted and rejected turns from ``runs/<batch_id>`` and
-emits a JSONL shard matching :mod:`schemas/dpo.schema.json`.
+The script reads accepted and rejected turns from ``runs/<batch_id>`` by
+default and emits a JSONL shard matching :mod:`schemas/dpo.schema.json`.
+Alternative root directories can be provided via ``--runs-dir`` and
+``--datasets-dir``.
 
 For each ``(speaker, topic)`` combination exactly one entry is produced.  A
 rejected turn with the same ``speaker`` and ``topic`` is preferred; if none is
@@ -44,13 +46,23 @@ def _load_turn(path: Path) -> Dict[str, Any]:
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--batch", required=True, help="Batch identifier")
+    ap.add_argument(
+        "--runs-dir",
+        default="runs",
+        help="Root directory containing run artifacts (default: runs)",
+    )
+    ap.add_argument(
+        "--datasets-dir",
+        default="datasets",
+        help="Root directory for dataset shards (default: datasets)",
+    )
     args = ap.parse_args()
 
     batch_id = args.batch
-    base_dir = Path("runs") / batch_id
+    base_dir = Path(args.runs_dir) / batch_id
     acc_dir = base_dir / "accepted"
     rej_dir = base_dir / "rejected"
-    out_dir = Path("datasets") / "dpo"
+    out_dir = Path(args.datasets_dir) / "dpo"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if not acc_dir.exists():
@@ -103,4 +115,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
-

--- a/src/pack_sft.py
+++ b/src/pack_sft.py
@@ -28,9 +28,10 @@ turn is::
         }
     }
 
-Only files under ``runs/<batch_id>/accepted`` are inspected.  The resulting
-shard is written to ``datasets/sft/<batch_id>.jsonl`` and can be validated via
-``python -m src.validate_jsonl``.
+By default files under ``runs/<batch_id>/accepted`` are inspected and the
+resulting shard is written to ``datasets/sft/<batch_id>.jsonl``.  Alternative
+locations can be supplied via ``--runs-dir`` and ``--datasets-dir``.
+The output can be validated via ``python -m src.validate_jsonl``.
 """
 
 from __future__ import annotations
@@ -67,8 +68,7 @@ def _load_turn(path: Path) -> Dict[str, Any]:
         or data.get("prompt", ""),
         "citations": meta.get("citations") or data.get("citations", []),
         "provenance": meta.get("provenance") or data.get("provenance", []),
-        "audit_summary": meta.get("audit_summary")
-        or data.get("audit_summary", {}),
+        "audit_summary": meta.get("audit_summary") or data.get("audit_summary", {}),
         "encoder": meta.get("encoder", ""),
         "model": meta.get("model", ""),
         "commit": meta.get("commit", ""),
@@ -79,11 +79,21 @@ def _load_turn(path: Path) -> Dict[str, Any]:
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--batch", required=True, help="Batch identifier")
+    ap.add_argument(
+        "--runs-dir",
+        default="runs",
+        help="Root directory containing run artifacts (default: runs)",
+    )
+    ap.add_argument(
+        "--datasets-dir",
+        default="datasets",
+        help="Root directory for dataset shards (default: datasets)",
+    )
     args = ap.parse_args()
 
     batch_id = args.batch
-    runs_dir = Path("runs") / batch_id / "accepted"
-    out_dir = Path("datasets") / "sft"
+    runs_dir = Path(args.runs_dir) / batch_id / "accepted"
+    out_dir = Path(args.datasets_dir) / "sft"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if not runs_dir.exists():
@@ -120,4 +130,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
-

--- a/tests/test_pack_scripts.py
+++ b/tests/test_pack_scripts.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pack_scripts_custom_paths(tmp_path):
+    runs_dir = tmp_path / "runs"
+    datasets_dir = tmp_path / "datasets"
+    acc_dir = runs_dir / "batch1" / "accepted"
+    rej_dir = runs_dir / "batch1" / "rejected"
+    acc_dir.mkdir(parents=True)
+    rej_dir.mkdir(parents=True)
+
+    accepted = [
+        {
+            "instruction": "t1",
+            "response": "r1",
+            "meta": {"speaker": "s", "topic": "t1"},
+        },
+        {
+            "instruction": "t2",
+            "response": "r2",
+            "meta": {"speaker": "s", "topic": "t2"},
+        },
+    ]
+    for i, data in enumerate(accepted):
+        (acc_dir / f"{i}.json").write_text(json.dumps(data), encoding="utf-8")
+
+    rejected = {
+        "instruction": "t1",
+        "response": "bad",
+        "meta": {"speaker": "s", "topic": "t1"},
+    }
+    (rej_dir / "0.json").write_text(json.dumps(rejected), encoding="utf-8")
+
+    result_sft = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.pack_sft",
+            "--batch",
+            "batch1",
+            "--runs-dir",
+            str(runs_dir),
+            "--datasets-dir",
+            str(datasets_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result_sft.returncode == 0, result_sft.stdout + result_sft.stderr
+    sft_path = datasets_dir / "sft" / "batch1.jsonl"
+    assert sft_path.exists()
+    assert len(sft_path.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+    result_dpo = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.pack_dpo",
+            "--batch",
+            "batch1",
+            "--runs-dir",
+            str(runs_dir),
+            "--datasets-dir",
+            str(datasets_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result_dpo.returncode == 0, result_dpo.stdout + result_dpo.stderr
+    dpo_path = datasets_dir / "dpo" / "batch1.jsonl"
+    assert dpo_path.exists()
+    assert len(dpo_path.read_text(encoding="utf-8").strip().splitlines()) == 2


### PR DESCRIPTION
## Summary
- allow `pack_sft` and `pack_dpo` to receive custom run and dataset directories
- add regression test covering the new CLI options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fe0f4c1a883239951f07f2ec3b6f9